### PR TITLE
Add default timezone to timestamps

### DIFF
--- a/etrv2mqtt/etrvutils.py
+++ b/etrv2mqtt/etrvutils.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from libetrv.bluetooth import btle
 from libetrv.device import eTRVDevice
 from datetime import datetime
+from datetime import timezone
 
 
 @dataclass(repr=False)
@@ -31,7 +32,8 @@ class eTRVUtils:
 
     @staticmethod
     def read_device(device: eTRVDevice) -> eTRVData:
-        return eTRVData(device.name, device.battery, device.temperature.room_temperature, device.temperature.set_point_temperature, datetime.now())
+        return eTRVData(device.name, device.battery, device.temperature.room_temperature,
+            device.temperature.set_point_temperature, datetime.now(timezone.utc))
 
     @staticmethod
     def set_temperature(device: eTRVDevice, temperature: float):

--- a/tests/dummyDevice.py
+++ b/tests/dummyDevice.py
@@ -5,6 +5,7 @@ from etrv2mqtt.config import ThermostatConfig, Config
 from etrv2mqtt.etrvutils import eTRVData
 from loguru import logger
 from datetime import datetime
+from datetime import timezone
 
 
 @dataclass
@@ -26,7 +27,7 @@ class DummyDevice(DeviceBase):
     def poll(self, mqtt: Mqtt):
         logger.debug("Polling data from {}", self._device.name)
         ret = eTRVData(self._device.name, self._device.battery,
-                       self._device.current_temp, self._device.set_point, datetime.now())
+                       self._device.current_temp, self._device.set_point, datetime.now(timezone.utc))
         logger.debug(str(ret))
         mqtt.publish_device_data(self._device.name, str(ret))
 


### PR DESCRIPTION
In order to get rid of HA Core "missing timezone information" errors.

Related HA Core commit which introduced the issue:
https://github.com/home-assistant/core/commit/69b749532429a4cdfdebee01dc680deb8cd93770