### PR TITLE
autodiscovery.py: Change thermostat mode from 'heat' to 'auto'

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ Install etrv2mqtt
 ```sh
 mkdir -p ~/venv/etrv2mqtt
 virtualenv ~/venv/etrv2mqtt
-~/venv/etrv2mqtt/bin/pip3 install 'git+https://github.com/keton/etrv2mqtt.git'
+~/venv/etrv2mqtt/bin/pip3 install 'git+https://github.com/Cymaphore/etrv2mqtt.git'
 ```
 
 ## Configuration
 Minimal `config.json` example. All parameters are described [here](docs/config_json.md).
 ```json
 {
-    "$schema": "https://raw.githubusercontent.com/keton/etrv2mqtt/master/etrv2mqtt/schemas/config.schema.json",
+    "$schema": "https://raw.githubusercontent.com/Cymaphore/etrv2mqtt/master/etrv2mqtt/schemas/config.schema.json",
     "thermostats": [
         {
             "topic": "Room",

--- a/docs/config_json.md
+++ b/docs/config_json.md
@@ -70,23 +70,45 @@
 	 - <i id="#config.schema.json/properties/options">path: #config.schema.json/properties/options</i>
 	 - Default: `[object Object]`
 	 - **_Properties_**
+		 - <b id="#config.schema.json/properties/options/properties/poll_interval">poll_schedule</b>
+			 - _Polling schedule to use (regular interval, every hour at specified minute)_
+			 - Type: `enum`
+			 - <i id="#config.schema.json/properties/options/properties/poll_schedule">path: #config.schema.json/properties/options/properties/poll_schedule</i>
+			 - Default: `interval`
+			 - Possible values:  `interval`, `hour_minute`
 		 - <b id="#config.schema.json/properties/options/properties/poll_interval">poll_interval</b>
 			 - _Interval between thermostat data readouts in seconds_
 			 - Type: `integer`
 			 - <i id="#config.schema.json/properties/options/properties/poll_interval">path: #config.schema.json/properties/options/properties/poll_interval</i>
 			 - Default: `3600`
 			 - Range:  &ge; 1
+		 - <b id="#config.schema.json/properties/options/properties/poll_interval">poll_hour_minute</b>
+			 - _The minute of the hour polling starts (only used when poll_schedule is hour_minute_
+			 - Type: `integer`
+			 - <i id="#config.schema.json/properties/options/properties/poll_hour_minute">path: #config.schema.json/properties/options/properties/poll_hour_minute</i>
+			 - Default: `0`
+			 - Range:  0 - 59
 		 - <b id="#config.schema.json/properties/options/properties/retry_limit">retry_limit</b>
 			 - _Limit of BLE connect attempts_
 			 - Type: `integer`
 			 - <i id="#config.schema.json/properties/options/properties/retry_limit">path: #config.schema.json/properties/options/properties/retry_limit</i>
 			 - Default: `5`
 			 - Range:  &ge; 0
+		 - <b id="#config.schema.json/properties/options/properties/retry_limit">retry_rerun</b>
+			 - _Retry failed thermostats once again after the end of the queue_
+			 - Type: `boolean`
+			 - <i id="#config.schema.json/properties/options/properties/retry_rerun">path: #config.schema.json/properties/options/properties/retry_rerun</i>
+			 - Default: `true`
 		 - <b id="#config.schema.json/properties/options/properties/stay_connected">stay_connected</b>
 			 - _Set to true in order to leave BLE connection running after polling thermostat data or setting temperature. May drain battery._
 			 - Type: `boolean`
 			 - <i id="#config.schema.json/properties/options/properties/stay_connected">path: #config.schema.json/properties/options/properties/stay_connected</i>
 			 - Default: _false_
+		 - <b id="#config.schema.json/properties/options/properties/retry_limit">idle_block_ble</b>
+			 - _Disable Bluetooth when idle (requires sudo permissions for rfkill) - EXPERIMENTAL, avoid battery draining_
+			 - Type: `boolean`
+			 - <i id="#config.schema.json/properties/options/properties/idle_block_ble">path: #config.schema.json/properties/options/properties/idle_block_ble</i>
+			 - Default: `false`
 		 - <b id="#config.schema.json/properties/options/properties/report_room_temperature">report_room_temperature</b>
 			 - _Set to false to disable reporting current room temperature as a separate Home Assistant sensor in MQTT auto discovery_
 			 - Type: `boolean`

--- a/etrv2mqtt/autodiscovery.py
+++ b/etrv2mqtt/autodiscovery.py
@@ -41,12 +41,14 @@ class Autodiscovery():
 
     _battery_template = json.loads("""
     {
+        "entity_category": "diagnostic",
         "device_class": "battery",
         "name": "kitchen battery",
         "unique_id":"0000_battery",
         "state_topic": "etrv/kitchen/state",
         "value_template": "{{ value_json.battery }}",
         "unit_of_measurement": "%",
+        "state_class": "measurement",
         "device": {
             "identifiers":"0000",
             "manufacturer": "Danfoss",
@@ -60,6 +62,7 @@ class Autodiscovery():
 
     _reported_name_template = json.loads("""
     {
+        "entity_category": "diagnostic",
         "name": "kitchen reported name",
         "unique_id":"0000_rep_name",
         "state_topic": "etrv/kitchen/state",
@@ -83,6 +86,7 @@ class Autodiscovery():
         "state_topic": "etrv/kitchen/state",
         "value_template": "{{ value_json.room_temp }}",
         "unit_of_measurement": "°C",
+        "state_class": "measurement",
         "device": {
             "identifiers":"0000",
             "manufacturer": "Danfoss",
@@ -96,6 +100,7 @@ class Autodiscovery():
 
     _last_update_template = json.loads("""
     {
+        "entity_category": "diagnostic",
         "device_class": "timestamp",
         "name": "Kitchen Last Update",
         "unique_id":"0000_last_update",

--- a/etrv2mqtt/autodiscovery.py
+++ b/etrv2mqtt/autodiscovery.py
@@ -25,7 +25,9 @@ class Autodiscovery():
         "min_temp":"10",
         "max_temp":"40",
         "temp_step":"0.5",
-        "modes":["heat"],
+        "modes":["auto"],
+        "mode_state_topic":"etrv2mqtt/state",
+        "mode_state_template":"{{ 'auto' }}",
         "device": {
             "identifiers":"0000",
             "manufacturer": "Danfoss",
@@ -139,6 +141,7 @@ class Autodiscovery():
         autodiscovery_msg = self._autodiscovery_payload(
             self._termostat_template, dev_mac, dev_name, "Thermostat")
         autodiscovery_msg['~'] = self._config.mqtt.base_topic+'/'+dev_name
+        autodiscovery_msg['mode_state_topic'] = self._config.mqtt.base_topic + "/state"
 
         return AutodiscoveryResult(autodiscovery_topic, payload=json.dumps(autodiscovery_msg))
 

--- a/etrv2mqtt/autodiscovery.py
+++ b/etrv2mqtt/autodiscovery.py
@@ -25,6 +25,7 @@ class Autodiscovery():
         "min_temp":"10",
         "max_temp":"40",
         "temp_step":"0.5",
+        "suggested_display_precision": "1",
         "modes":["auto"],
         "mode_state_topic":"etrv2mqtt/state",
         "mode_state_template":"{{ 'auto' }}",
@@ -48,6 +49,7 @@ class Autodiscovery():
         "state_topic": "etrv/kitchen/state",
         "value_template": "{{ value_json.battery }}",
         "unit_of_measurement": "%",
+        "suggested_display_precision": "0",
         "state_class": "measurement",
         "device": {
             "identifiers":"0000",
@@ -86,6 +88,7 @@ class Autodiscovery():
         "state_topic": "etrv/kitchen/state",
         "value_template": "{{ value_json.room_temp }}",
         "unit_of_measurement": "°C",
+        "suggested_display_precision": "1",
         "state_class": "measurement",
         "device": {
             "identifiers":"0000",

--- a/etrv2mqtt/config.py
+++ b/etrv2mqtt/config.py
@@ -74,6 +74,7 @@ class Config:
             _config_json['mqtt']['hass_birth_payload'],
         )
         self.retry_limit: int = _config_json['options']['retry_limit']
+        self.retry_rerun: bool = _config_json['options']['retry_rerun']
         self.poll_schedule: str = _config_json['options']['poll_schedule']
         self.poll_interval: int = _config_json['options']['poll_interval']
         self.poll_hour_minute: int = _config_json['options']['poll_hour_minute']

--- a/etrv2mqtt/config.py
+++ b/etrv2mqtt/config.py
@@ -74,7 +74,9 @@ class Config:
             _config_json['mqtt']['hass_birth_payload'],
         )
         self.retry_limit: int = _config_json['options']['retry_limit']
+        self.poll_schedule: str = _config_json['options']['poll_schedule']
         self.poll_interval: int = _config_json['options']['poll_interval']
+        self.poll_hour_minute: int = _config_json['options']['poll_hour_minute']
         self.stay_connected: bool = _config_json['options']['stay_connected']
         self.report_room_temperature: bool = _config_json['options']['report_room_temperature']
         self.setpoint_debounce_time: int = _config_json['options']['setpoint_debounce_time']

--- a/etrv2mqtt/config.py
+++ b/etrv2mqtt/config.py
@@ -23,6 +23,7 @@ class _MQTTConfig:
     autodiscovery: bool
     autodiscovery_topic: str
     autodiscovery_retain: bool
+    device_data_retain: bool
     hass_birth_topic: str
     hass_birth_payload: str
 
@@ -70,6 +71,7 @@ class Config:
             _config_json['mqtt']['autodiscovery'],
             _config_json['mqtt']['autodiscovery_topic'],
             _config_json['mqtt']['autodiscovery_retain'],
+            _config_json['mqtt']['device_data_retain'],
             _config_json['mqtt']['hass_birth_topic'],
             _config_json['mqtt']['hass_birth_payload'],
         )

--- a/etrv2mqtt/config.py
+++ b/etrv2mqtt/config.py
@@ -75,6 +75,7 @@ class Config:
         )
         self.retry_limit: int = _config_json['options']['retry_limit']
         self.retry_rerun: bool = _config_json['options']['retry_rerun']
+        self.idle_block_ble: bool = _config_json['options']['idle_block_ble']
         self.poll_schedule: str = _config_json['options']['poll_schedule']
         self.poll_interval: int = _config_json['options']['poll_interval']
         self.poll_hour_minute: int = _config_json['options']['poll_hour_minute']

--- a/etrv2mqtt/devices.py
+++ b/etrv2mqtt/devices.py
@@ -47,8 +47,14 @@ class TRVDevice(DeviceBase):
 
             if self._stay_connected == False:
                 self._device.disconnect()
+        except btle.BTLEInternalError as e:
+            logger.error(e)
+            if self._device.is_connected():
+                self._device.disconnect()
         except btle.BTLEDisconnectError as e:
             logger.error(e)
+            if self._device.is_connected():
+                self._device.disconnect()
 
     def set_temperature(self, mqtt: Mqtt, temperature: float):
         try:

--- a/etrv2mqtt/devices.py
+++ b/etrv2mqtt/devices.py
@@ -8,12 +8,14 @@ from etrv2mqtt.config import Config, ThermostatConfig
 from etrv2mqtt.etrvutils import eTRVUtils
 from etrv2mqtt.mqtt import Mqtt
 from typing import Type, Dict, NoReturn
+import os
 import schedule
 
 
 class DeviceBase(ABC):
     def __init__(self, thermostat_config: ThermostatConfig, config: Config):
         super().__init__()
+        self._config = config
 
     @abstractmethod
     def poll(self, mqtt: Mqtt):
@@ -22,7 +24,6 @@ class DeviceBase(ABC):
     @abstractmethod
     def set_temperature(self, mqtt: Mqtt, temperature: float):
         pass
-
 
 class TRVDevice(DeviceBase):
     def __init__(self, thermostat_config: ThermostatConfig, config: Config):
@@ -65,10 +66,18 @@ class TRVDevice(DeviceBase):
             if not self._device.is_connected():
                 self._device.connect()
             eTRVUtils.set_temperature(self._device, temperature)
+            if self._stay_connected == False:
+                self._device.disconnect()
             # Home assistant needs to see updated temperature value to confirm change
             self.poll(mqtt)
         except btle.BTLEDisconnectError as e:
             logger.error(e)
+            if self._device.is_connected():
+                self._device.disconnect()
+        except btle.BTLEInternalError as e:
+            logger.error(e)
+            if self._device.is_connected():
+                self._device.disconnect()
 
 
 class DeviceManager():
@@ -86,6 +95,7 @@ class DeviceManager():
         self._mqtt.hass_birth_callback = self._hass_birth_callback
 
     def _poll_devices(self):
+        self.ble_on()
         rerun = []
         for device in self._devices.values():
             if not device.poll(self._mqtt):
@@ -96,6 +106,7 @@ class DeviceManager():
             time.sleep(5)
             for device in rerun:
                 device.poll(self._mqtt)
+        self.ble_off()
 
     def poll_forever(self) -> NoReturn:
         if self._config.poll_schedule == "hour_minute":
@@ -120,7 +131,9 @@ class DeviceManager():
                 time.sleep(2)
 
     def _set_temerature_task(self, device: DeviceBase, temperature: float):
+        self.ble_on()
         device.set_temperature(self._mqtt, temperature)
+        self.ble_off()
         # this will cause the task to be executed only once
         return schedule.CancelJob
 
@@ -140,3 +153,13 @@ class DeviceManager():
 
     def _hass_birth_callback(self, mqtt: Mqtt):
         schedule.run_all(delay_seconds=1)
+
+    def ble_off(self):
+        if self._config.idle_block_ble:
+            logger.info("Disable Bluetooth")
+            os.system("sudo rfkill block bluetooth")
+
+    def ble_on(self):
+        if self._config.idle_block_ble:
+            logger.info("Enable Bluetooth")
+            os.system("sudo rfkill unblock bluetooth")

--- a/etrv2mqtt/devices.py
+++ b/etrv2mqtt/devices.py
@@ -82,8 +82,12 @@ class DeviceManager():
             device.poll(self._mqtt)
 
     def poll_forever(self) -> NoReturn:
-        schedule.every(self._config.poll_interval).seconds.do(
-            self._poll_devices)
+        if self._config.poll_schedule == "hour_minute":
+            schedule.every().hour.at(":{0:02d}".format(self._config.poll_hour_minute)).do(
+                self._poll_devices)
+        else: # for poll_schedule=interval and as fallback
+            schedule.every(self._config.poll_interval).seconds.do(
+                self._poll_devices)
         mqtt_was_connected: bool = False
 
         while True:

--- a/etrv2mqtt/mqtt.py
+++ b/etrv2mqtt/mqtt.py
@@ -38,7 +38,7 @@ class Mqtt(object):
     def publish_device_data(self, name: str, data: str):
         if self._client.is_connected():
             self._client.publish(
-                self._config.mqtt.base_topic+'/'+name+'/state', payload=data)
+                self._config.mqtt.base_topic+'/'+name+'/state', payload=data, retain=self._config.mqtt.device_data_retain)
 
     def _publish_autodiscovery_result(self, result: AutodiscoveryResult, retain: bool = False):
         self._client.publish(

--- a/etrv2mqtt/schemas/config.schema.json
+++ b/etrv2mqtt/schemas/config.schema.json
@@ -71,11 +71,24 @@
             "default": {},
             "description": "Options common for all thermostats",
             "properties": {
+                "poll_schedule": {
+                    "type": "string",
+                    "description": "Polling schedule to use (regular interval, every hour at specified minute)",
+                    "enum": [ "interval", "hour_minute" ],
+                    "default": "interval"
+                },
                 "poll_interval": {
                     "type":"integer",
-                    "description": "Interval between thermostat data readouts in seconds",
+                    "description": "Interval between thermostat data readouts in seconds (only used when poll_schedule is interval)",
                     "minimum": 1,
                     "default": 3600
+                },
+                "poll_hour_minute": {
+                    "type": "integer",
+                    "description": "The minute of the hour polling starts (only used when poll_schedule is hour_minute",
+                    "minimum": 0,
+                    "maximum": 59,
+                    "default": 0
                 },
                 "retry_limit": {
                     "type":"integer",

--- a/etrv2mqtt/schemas/config.schema.json
+++ b/etrv2mqtt/schemas/config.schema.json
@@ -96,6 +96,11 @@
                     "minimum": 0,
                     "default": 5
                 },
+                "retry_rerun": {
+                    "type": "boolean",
+                    "description": "Retry failed thermostats once again after the end of the queue",
+                    "default": true
+                },
                 "stay_connected": {
                     "type": "boolean",
                     "description": "Set to true in order to leave BLE connection running after polling thermostat data or setting temperature. May drain battery.",

--- a/etrv2mqtt/schemas/config.schema.json
+++ b/etrv2mqtt/schemas/config.schema.json
@@ -106,6 +106,11 @@
                     "description": "Set to true in order to leave BLE connection running after polling thermostat data or setting temperature. May drain battery.",
                     "default": false
                 },
+                "idle_block_ble": {
+                    "type": "boolean",
+                    "description": "Disable Bluetooth when idle (requires sudo permissions for rfkill) - EXPERIMENTAL, avoid battery draining",
+                    "default": false
+                },
                 "report_room_temperature": {
                     "type": "boolean",
                     "description": "Set to false to disable reporting current room temperature as a separate Home Assistant sensor in MQTT auto discovery",

--- a/etrv2mqtt/schemas/config.schema.json
+++ b/etrv2mqtt/schemas/config.schema.json
@@ -54,6 +54,11 @@
                     "default": true,
                     "description": "Set retain bit on autodiscovery related messages"
                 },
+                "device_data_retain": {
+                    "type":"boolean",
+                    "default": false,
+                    "description": "Set retain bit on device data messages"
+                },
                 "hass_birth_topic": {
                     "type": "string",
                     "default": "hass/status",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 importlib-metadata==1.5.0
 jsonschema==3.2.0
-libetrv>=0.4.1
-loguru==0.4.1
+libetrv>=0.6.0
+loguru==0.5.3
 paho-mqtt==1.5.0
 schedule==0.6.0


### PR DESCRIPTION
Change to cause the Thermostat to report mode 'auto'. This is done by setting auto as the only available mode, using the state topic as mode state topic and providing a static mode state topic enforcing state auto.

This way the thermostat is properly visualised and not assumed to be always off.

[edit] Additional commit added by push: Configurable polling, schedule for specified minute of every hour